### PR TITLE
Fix pypi workflow as release:created trigger is not reliable

### DIFF
--- a/.github/workflows/documentation-deploy-release.yml
+++ b/.github/workflows/documentation-deploy-release.yml
@@ -4,7 +4,7 @@ permissions: write-all
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   build-docs-and-deploy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Python distribution to PyPI
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Python distribution to PyPI
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
It seems from [the release of mibiremo v0.3.0 ](https://github.com/MiBiPreT/mibiremo/releases/tag/v0.3.0) that the [`release:created` ](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=created#release) trigger [did not start the pypi publishing workflow](https://github.com/MiBiPreT/mibiremo/actions?query=event%3Arelease). Why this exactly happened (or did not happen) is not yet completely clear to me but in fact it is either the [`release:published`](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release) trigger or the [`release:released`](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release) trigger that we want for publishing the pypi package. 

fix #36 