### PR TITLE
35 improve speed of saulyev algorithm in 1d semi lagrangian advection diffusion solver

### DIFF
--- a/mibiremo/semilagsolver.py
+++ b/mibiremo/semilagsolver.py
@@ -1,15 +1,41 @@
 """Semi-Lagrangian solver for 1D advection-diffusion equation on a uniform grid.
 
 Author: Matteo Masi
-Last revision: 17/02/2026
+Last revision: 17/03/2026
 
 """
 
 import warnings
 import numpy as np
 from scipy.interpolate import PchipInterpolator
+from numba import njit as _njit
 
 warnings.filterwarnings("ignore")
+
+
+@_njit(cache=True)
+def _saulyev_alt_numba(c_init, theta, c_bound):
+    """JIT-compiled Saul'yev alternating-direction."""
+    n = len(c_init)
+    clr = c_init.copy()
+    crl = c_init.copy()
+    inv = 1.0 / (1.0 + theta)
+
+    # L-R sweep
+    for i in range(n):
+        sola = theta * c_bound if i == 0 else theta * clr[i - 1]
+        solb = (1.0 - theta) * c_init[i]
+        solc = theta * c_init[i + 1] if i < n - 1 else theta * c_init[i]
+        clr[i] = (sola + solb + solc) * inv
+
+    # R-L sweep
+    for i in range(n - 1, -1, -1):
+        sola = theta * clr[-1] if i == n - 1 else theta * crl[i + 1]
+        solb = (1.0 - theta) * c_init[i]
+        solc = theta * c_init[i - 1] if i > 0 else theta * c_init[i]
+        crl[i] = (sola + solb + solc) * inv
+
+    return (clr + crl) * 0.5
 
 
 class SemiLagSolver:
@@ -190,38 +216,8 @@ class SemiLagSolver:
             approach eliminates the restrictive stability constraint of explicit
             methods while maintaining computational efficiency.
         """
-        dt = self.dt
-        theta = self.d * dt / (self.dx**2)
-
-        # Assign current C state as initial condition
-        c_init = self.C.copy()
-        clr = self.C.copy()
-        crl = self.C.copy()
-
-        # A) L-R direction
-        for i in range(len(clr)):
-            if i == 0:  # left boundary
-                sola = theta * c_bound
-            else:
-                sola = theta * clr[i - 1]
-            solb = (1 - theta) * c_init[i]
-            solc = theta * c_init[i + 1] if i < len(clr) - 1 else theta * c_init[i]
-            # L-R Solution
-            clr[i] = (sola + solb + solc) / (1 + theta)
-
-        # B) R-L direction
-        for i in range(len(crl) - 1, -1, -1):
-            if i == len(crl) - 1:  # right boundary (take from LR solution)
-                sola = theta * clr[-1]
-            else:
-                sola = theta * crl[i + 1]
-            solb = (1 - theta) * c_init[i]
-            solc = theta * c_init[i - 1] if i > 0 else theta * c_init[i]
-            # R-L Solution
-            crl[i] = (sola + solb + solc) / (1 + theta)
-
-        # Average L-R and R-L solutions and update to final state
-        self.C = (clr + crl) / 2
+        theta = self.d * self.dt / (self.dx**2)
+        self.C = _saulyev_alt_numba(self.C, theta, float(c_bound))
 
     def transport(self, c_bound) -> np.ndarray:
         """Perform one complete transport time step with coupled advection-diffusion.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "matplotlib",
     "pyqt5",
     "scipy",
+    "numba>=0.64",
 ]
 description = "Microbiome Bioremediation Reaction Module: a Python interface to PhreeqcRM library"
 keywords = ["Microbiome"," Bioremediation"," Chemical Reaction"," Geochemical Engineering"]

--- a/scripts/benchmark_semilag.py
+++ b/scripts/benchmark_semilag.py
@@ -1,0 +1,88 @@
+"""Benchmark: compare speed of pure-Python Sauly'ev algotithm
+vs the Numba-optimized version in SemiLagSolver.saulyev_solver_alt()
+"""
+
+import time
+import warnings
+
+import numpy as np
+from mibiremo.semilagsolver import SemiLagSolver
+
+warnings.filterwarnings("ignore")
+
+
+class _PurePythonSolver(SemiLagSolver):
+    """pure-Python Saulyev implementation for benchmarking purposes"""
+
+    def saulyev_solver_alt(self, c_bound):
+        theta = self.d * self.dt / (self.dx**2)
+        c_init = self.C.copy()
+        clr = self.C.copy()
+        crl = self.C.copy()
+        inv = 1.0 / (1.0 + theta)
+
+        for i in range(len(clr)):
+            sola = theta * c_bound if i == 0 else theta * clr[i - 1]
+            solb = (1 - theta) * c_init[i]
+            solc = theta * c_init[i + 1] if i < len(clr) - 1 else theta * c_init[i]
+            clr[i] = (sola + solb + solc) * inv
+
+        for i in range(len(crl) - 1, -1, -1):
+            sola = theta * clr[-1] if i == len(crl) - 1 else theta * crl[i + 1]
+            solb = (1 - theta) * c_init[i]
+            solc = theta * c_init[i - 1] if i > 0 else theta * c_init[i]
+            crl[i] = (sola + solb + solc) * inv
+
+        self.C = (clr + crl) / 2
+
+
+def make_solver(solver, n):
+    x = np.linspace(0, 10, n)
+    c = np.exp(-((x - 2) ** 2) / 0.5)
+    return solver(x, c, 0.3, 0.01, 0.1)
+
+
+def benchmark(fn, n_warmup=3, n_runs=100):
+    # First run a few warmup iterations
+    for _ in range(n_warmup):
+        fn()
+    t0 = time.perf_counter()
+    # Then run the actual benchmark
+    for _ in range(n_runs):
+        fn()
+    return (time.perf_counter() - t0) / n_runs * 1e6  # µs
+
+
+def run_all(n_grid, n_runs=500):
+    s_py = make_solver(_PurePythonSolver, n_grid)
+    s_opt = make_solver(SemiLagSolver, n_grid)
+    c_ini = s_py.C.copy()
+
+    def bench_py():
+        s_py.C = c_ini.copy()
+        s_py.saulyev_solver_alt(1.0)
+
+    def bench_opt():
+        s_opt.C = c_ini.copy()
+        s_opt.saulyev_solver_alt(1.0)
+
+    t_py = benchmark(bench_py, n_runs=n_runs)
+    t_def = benchmark(bench_opt, n_runs=n_runs)
+
+    sep = "=" * 60
+    print(f"\n{sep}")
+    print(f"  saulyev_solver_alt  grid={n_grid}  runs={n_runs}")
+    print(sep)
+    print(f"  {'Strategy':<36s}  {'µs/call':>8s}  {'speedup':>7s}")
+    print(f"  {'-' * 36}  {'-' * 8}  {'-' * 7}")
+    print(f"  {'pure-Python':<36s}  {t_py:8.2f}  {'1.00x':>7s}")
+    print(f"  {'Numba JIT':<36s}  {t_def:8.2f}  {t_py / t_def:7.2f}x")
+    print(f"{sep}\n")
+
+
+if __name__ == "__main__":
+    # Run benchmarks for various grid sizes and number of runs
+    run_all(n_grid=200, n_runs=1000)
+    run_all(n_grid=500, n_runs=500)
+    run_all(n_grid=2000, n_runs=200)
+    run_all(n_grid=10000, n_runs=50)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""pytest configuration for the mibiremo test suite.
+
+Set NUMBA_DISABLE_JIT=1 at module level to disable JIT compilation during testing
+"""
+
+import os
+
+os.environ["NUMBA_DISABLE_JIT"] = "1"

--- a/tests/test_semilagsolver.py
+++ b/tests/test_semilagsolver.py
@@ -2,6 +2,7 @@
 
 import pytest
 import numpy as np
+import mibiremo.semilagsolver as _mod
 from mibiremo.semilagsolver import SemiLagSolver
 
 
@@ -321,3 +322,20 @@ class TestTransportMethod:
         assert c_result is solver.C
         # Should be a numpy array
         assert isinstance(c_result, np.ndarray)
+
+
+class TestNumericalConsistency:
+    """Tests for the JIT-compiled Saul'yev kernel."""
+
+    def test_numba_function_directly(self):
+        """Call _saulyev_alt_numba directly and verify output shape and finiteness."""
+        rng = np.random.default_rng(7)
+        c_init = rng.random(51)
+        theta = 0.5
+        c_bound = 0.3
+
+        result = _mod._saulyev_alt_numba(c_init.copy(), theta, c_bound)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == c_init.shape
+        assert np.all(np.isfinite(result))


### PR DESCRIPTION
Added Numba JIT compilation of Saul'yev solver for diffusion (dispersion), with significant speed up of the for loop.
The Numba functions cannot directly be tested, so during test runs an environment variable `os.environ["NUMBA_DISABLE_JIT"] = "1"` is set in `conftest.py` to disable Numba.
A benchmark script `benchmark_semilag.py` was also added to see the speed increase of the pure-python function vs the optimized one.